### PR TITLE
order computers by id

### DIFF
--- a/controllers/computer-ctrl.js
+++ b/controllers/computer-ctrl.js
@@ -8,7 +8,7 @@
 module.exports.getComputers = (req, res, next) => {
   const { computer } = req.app.get('models');
   computer
-    .findAll()
+    .findAll({ order: ['id'] })
     .then(computers => {
       res.render('computers-list', { computers });
     })


### PR DESCRIPTION
Related Issue: #8 

Description:
after update, computer items stay in same order at /computers

PR Testing Steps:
- decommission computer 2, should stay in order
- extension of last pr
